### PR TITLE
PT-14218: Support different search provider for each document type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,27 +3,22 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = crlf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 # Project files
 [*.{csproj,props}]
-indent_size = 2
 insert_final_newline = false
-
-# JSON files
-[*.json]
-indent_size = 2
-
-# Configuration files
-[*.config]
-indent_size = 2
 
 # HTML files
 [*.{html,htm}]
 insert_final_newline = false
+
+# Code
+[*.{cs,js,ts,ps1,sh,bat,cmd}]
+indent_size = 4
 
 # Dotnet code style settings
 [*.{cs,vb}]

--- a/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -13,7 +13,7 @@
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.253.1" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.223.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.400.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.721-pt-14218" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.400.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.721-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticSearch8.Data/Extensions/SettingsExtensions.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Extensions/SettingsExtensions.cs
@@ -7,42 +7,42 @@ namespace VirtoCommerce.ElasticSearch8.Data.Extensions
     {
         public static int GetFieldsLimit(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<int>(ModuleSettings.IndexTotalFieldsLimit);
+            return settingsManager.GetValue<int>(ModuleSettings.IndexTotalFieldsLimit);
         }
 
         public static string GetTokenFilterName(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<string>(ModuleSettings.TokenFilter);
+            return settingsManager.GetValue<string>(ModuleSettings.TokenFilter);
         }
 
         public static int GetMinGram(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<int>(ModuleSettings.MinGram);
+            return settingsManager.GetValue<int>(ModuleSettings.MinGram);
         }
 
         public static int GetMaxGram(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<int>(ModuleSettings.MaxGram);
+            return settingsManager.GetValue<int>(ModuleSettings.MaxGram);
         }
 
         public static bool GetSemanticSearchEnabled(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<bool>(ModuleSettings.EnableSemanticSearch);
+            return settingsManager.GetValue<bool>(ModuleSettings.EnableSemanticSearch);
         }
 
         public static string GetPipelineName(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<string>(ModuleSettings.SemanticPipelineName);
+            return settingsManager.GetValue<string>(ModuleSettings.SemanticPipelineName);
         }
 
         public static string GetModelId(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<string>(ModuleSettings.SemanticModelId);
+            return settingsManager.GetValue<string>(ModuleSettings.SemanticModelId);
         }
 
         public static string GetModelFieldName(this ISettingsManager settingsManager)
         {
-            return settingsManager.GetValueByDescriptor<string>(ModuleSettings.SemanticFieldName);
+            return settingsManager.GetValue<string>(ModuleSettings.SemanticFieldName);
         }
     }
 }

--- a/src/VirtoCommerce.ElasticSearch8.Data/VirtoCommerce.ElasticSearch8.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Data/VirtoCommerce.ElasticSearch8.Data.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.253.1" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.400.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.ElasticSearch8.Web/Module.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Web/Module.cs
@@ -5,10 +5,9 @@ using VirtoCommerce.ElasticSearch8.Core;
 using VirtoCommerce.ElasticSearch8.Core.Models;
 using VirtoCommerce.ElasticSearch8.Core.Services;
 using VirtoCommerce.ElasticSearch8.Data.Services;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
-using VirtoCommerce.SearchModule.Core.Services;
+using VirtoCommerce.SearchModule.Core.Extensions;
 
 namespace VirtoCommerce.ElasticSearch8.Web;
 
@@ -17,40 +16,29 @@ public class Module : IModule, IHasConfiguration
     public ManifestModuleInfo ModuleInfo { get; set; }
     public IConfiguration Configuration { get; set; }
 
-    private bool IsElasticEnabled
-    {
-        get
-        {
-            var provider = Configuration.GetValue<string>("Search:Provider");
-            return provider.EqualsInvariant("ElasticSearch8");
-        }
-    }
-
     public void Initialize(IServiceCollection serviceCollection)
     {
-        if (IsElasticEnabled)
-        {
-            serviceCollection.Configure<ElasticSearch8Options>(Configuration.GetSection("Search:ElasticSearch8"));
-            serviceCollection.AddSingleton<ISearchProvider, ElasticSearch8Provider>();
+        serviceCollection.Configure<ElasticSearch8Options>(Configuration.GetSection("Search:ElasticSearch8"));
+        serviceCollection.AddSingleton<ElasticSearch8Provider>();
 
-            serviceCollection.AddSingleton<IElasticSearchFiltersBuilder, ElasticSearchFiltersBuilder>();
-            serviceCollection.AddSingleton<IElasticSearchAggregationsBuilder, ElasticSearchAggregationsBuilder>();
+        serviceCollection.AddSingleton<IElasticSearchFiltersBuilder, ElasticSearchFiltersBuilder>();
+        serviceCollection.AddSingleton<IElasticSearchAggregationsBuilder, ElasticSearchAggregationsBuilder>();
 
-            serviceCollection.AddSingleton<IElasticSearchRequestBuilder, ElasticSearchRequestBuilder>();
-            serviceCollection.AddSingleton<IElasticSearchResponseBuilder, ElasticSearchResponseBuilder>();
+        serviceCollection.AddSingleton<IElasticSearchRequestBuilder, ElasticSearchRequestBuilder>();
+        serviceCollection.AddSingleton<IElasticSearchResponseBuilder, ElasticSearchResponseBuilder>();
 
-            serviceCollection.AddSingleton<IElasticSearchPropertyService, ElasticSearchPropertyService>();
-        }
+        serviceCollection.AddSingleton<IElasticSearchPropertyService, ElasticSearchPropertyService>();
     }
 
     public void PostInitialize(IApplicationBuilder appBuilder)
     {
         var settingsRegistrar = appBuilder.ApplicationServices.GetRequiredService<ISettingsRegistrar>();
         settingsRegistrar.RegisterSettings(ModuleConstants.Settings.AllSettings, ModuleInfo.Id);
+
+        appBuilder.UseSearchProvider<ElasticSearch8Provider>("ElasticSearch8");
     }
 
     public void Uninstall()
-
     {
         // Nothing to do here
     }

--- a/src/VirtoCommerce.ElasticSearch8.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticSearch8.Web/module.manifest
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <id>VirtoCommerce.ElasticSearch8</id>
-    <version>3.202.0</version>
-    <version-tag></version-tag>
+  <id>VirtoCommerce.ElasticSearch8</id>
+  <version>3.202.0</version>
+  <version-tag></version-tag>
 
-    <platformVersion>3.253.1</platformVersion>
-    <dependencies>
-        <dependency id="VirtoCommerce.Search" version="3.233.0" />
-    </dependencies>
+  <platformVersion>3.400.0</platformVersion>
+  <dependencies>
+    <dependency id="VirtoCommerce.Search" version="3.403.0" />
+  </dependencies>
 
-    <title>Elastic Search 8</title>
-    <description>Indexed search functionality with Elastic 8 engines</description>
+  <title>Elastic Search 8</title>
+  <description>Indexed search functionality with Elastic 8 engines</description>
 
-    <authors>
-        <author>Konstantin Savosteev</author>
-    </authors>
-    <owners>
-        <owner>VirtoCommerce</owner>
-    </owners>
+  <authors>
+    <author>Konstantin Savosteev</author>
+  </authors>
+  <owners>
+    <owner>VirtoCommerce</owner>
+  </owners>
 
-    <projectUrl>https://github.com/VirtoCommerce/vc-module-elastic-search-8-x</projectUrl>
-    <iconUrl>Modules/$(VirtoCommerce.ElasticSearch8)/Content/logo.png</iconUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  <projectUrl>https://github.com/VirtoCommerce/vc-module-elastic-search-8-x</projectUrl>
+  <iconUrl>Modules/$(VirtoCommerce.ElasticSearch8)/Content/logo.png</iconUrl>
+  <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-    <assemblyFile>VirtoCommerce.ElasticSearch8.Web.dll</assemblyFile>
-    <moduleType>VirtoCommerce.ElasticSearch8.Web.Module, VirtoCommerce.ElasticSearch8.Web</moduleType>
+  <assemblyFile>VirtoCommerce.ElasticSearch8.Web.dll</assemblyFile>
+  <moduleType>VirtoCommerce.ElasticSearch8.Web.Module, VirtoCommerce.ElasticSearch8.Web</moduleType>
 
-    <releaseNotes>First version.</releaseNotes>
-    <copyright>Copyright © 2023 VirtoCommerce. All rights reserved</copyright>
-    <tags>extension module</tags>
-    <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
+  <releaseNotes>First version.</releaseNotes>
+  <copyright>Copyright © 2023 VirtoCommerce. All rights reserved</copyright>
+  <tags>extension module</tags>
+  <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.ElasticSearch8.Tests/ElasticSearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.ElasticSearch8.Tests/ElasticSearchProviderTestsBase.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Moq;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 
@@ -128,47 +129,44 @@ namespace VirtoCommerce.ElasticSearch8.Tests
         {
             var doc = new IndexDocument(id);
 
-            doc.Add(new IndexDocumentField("Content", name) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Content", color) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+            doc.AddFilterableStringAndContentString("Name", name);
+            doc.AddFilterableStringAndContentString("Color", color);
 
-            doc.Add(new IndexDocumentField("Code", id) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Name", name) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Color", color) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Size", size) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Date", DateTime.Parse(date)) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location)) { IsRetrievable = true, IsFilterable = true });
+            doc.AddFilterableString("Code", id);
+            doc.AddFilterableInteger("Size", size);
+            doc.AddFilterableDateTime("Date", DateTime.Parse(date));
+            doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location), IndexDocumentFieldValueType.GeoPoint) { IsRetrievable = true, IsFilterable = true });
 
-            doc.Add(new IndexDocumentField("Catalog", "Goods") { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Catalog", "Stuff") { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.AddFilterableCollection("Catalog", "Goods");
+            doc.AddFilterableCollection("Catalog", "Stuff");
 
-            doc.Add(new IndexDocumentField("NumericCollection", size) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("NumericCollection", 10) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("NumericCollection", 20) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", size, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", 10, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", 20, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
 
-            doc.Add(new IndexDocumentField("Is", "Priced") { IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Is", color) { IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Is", id) { IsFilterable = true, IsCollection = true });
+            doc.AddFilterableCollection("Is", "Priced");
+            doc.AddFilterableCollection("Is", color);
+            doc.AddFilterableCollection("Is", id);
 
-            doc.Add(new IndexDocumentField("StoredField", "This value should not be processed in any way, it is just stored in the index.") { IsRetrievable = true });
+            doc.Add(new IndexDocumentField("StoredField", "This value should not be processed in any way, it is just stored in the index.", IndexDocumentFieldValueType.String) { IsRetrievable = true });
 
             foreach (var price in prices)
             {
-                doc.Add(new IndexDocumentField($"Price_{price.Currency}_{price.Pricelist}", price.Amount) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-                doc.Add(new IndexDocumentField($"Price_{price.Currency}", price.Amount) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                doc.Add(new IndexDocumentField($"Price_{price.Currency}_{price.Pricelist}", price.Amount, IndexDocumentFieldValueType.Decimal) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                doc.Add(new IndexDocumentField($"Price_{price.Currency}", price.Amount, IndexDocumentFieldValueType.Decimal) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
             }
 
-            var hasMultiplePrices = prices.Length > 1;
-            doc.Add(new IndexDocumentField("HasMultiplePrices", hasMultiplePrices) { IsRetrievable = true, IsFilterable = true });
+            doc.AddFilterableBoolean("HasMultiplePrices", prices.Length > 1);
 
             // Adds extra fields to test mapping updates for indexer
             if (name2 != null)
             {
-                doc.Add(new IndexDocumentField("Name 2", name2) { IsRetrievable = true, IsFilterable = true });
+                doc.AddFilterableString("Name 2", name2);
             }
 
             if (date2 != null)
             {
-                doc.Add(new IndexDocumentField("Date (2)", date2) { IsRetrievable = true, IsFilterable = true });
+                doc.AddFilterableDateTime("Date (2)", date2.Value);
             }
 
             //doc.Add(new IndexDocumentField("__obj", obj) { IsRetrievable = true, IsFilterable = true });

--- a/tests/VirtoCommerce.ElasticSearch8.Tests/Unit/PropertyConverterTests.cs
+++ b/tests/VirtoCommerce.ElasticSearch8.Tests/Unit/PropertyConverterTests.cs
@@ -33,7 +33,7 @@ namespace VirtoCommerce.ElasticSearch8.Tests.Unit
             var target = new ElasticSearchPropertyService();
 
             // Act
-            var result = target.CreateProperty(new IndexDocumentField(name, value));
+            var result = target.CreateProperty(new IndexDocumentField(name, value, IndexDocumentFieldValueType.Complex));
 
             // Assert
             Assert.IsType<NestedProperty>(result);


### PR DESCRIPTION
## Description
Configuration example for default provider `ElasticAppSearch` and category provider `ElasticSearch8`:
```
{
  "Search": {
    "Provider": "ElasticAppSearch",
    "DocumentScopes": [
      {
        "DocumentType": "Category",
        "Provider": "ElasticSearch8"
      }
    ]
  }
}
```
## References
### QA-test:
### Jira-link:







https://virtocommerce.atlassian.net/browse/PT-14218
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.202.0-pr-5-cf76.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.202.0-pr-5-e4ab.zip

