### PR TITLE
VCST-336: min_score and boost configuration

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Core/ModuleConstants.cs
@@ -68,6 +68,13 @@ public static class ModuleConstants
                 DefaultValue = 20,
             };
 
+            public static SettingDescriptor MinScore { get; } = new()
+            {
+                Name = "VirtoCommerce.Search.ElasticSearch8.MinScore",
+                GroupName = "Search|ElasticSearch8|General",
+                ValueType = SettingValueType.Decimal,
+                DefaultValue = 0.1,
+            };
 
             public static SettingDescriptor SemanticSearchType { get; } = new()
             {
@@ -102,6 +109,22 @@ public static class ModuleConstants
                 DefaultValue = 384,
             };
 
+            public static SettingDescriptor SemanticBoost { get; } = new()
+            {
+                Name = "VirtoCommerce.Search.ElasticSearch8.SemanticBoost",
+                GroupName = "Search|ElasticSearch8|Semantic",
+                ValueType = SettingValueType.Decimal,
+                DefaultValue = 1.0M,
+            };
+
+            public static SettingDescriptor KeywordBoost { get; } = new()
+            {
+                Name = "VirtoCommerce.Search.ElasticSearch8.KeywordBoost",
+                GroupName = "Search|ElasticSearch8|Semantic",
+                ValueType = SettingValueType.Decimal,
+                DefaultValue = 1.0M,
+            };
+
             public static IEnumerable<SettingDescriptor> AllGeneralSettings
             {
                 get
@@ -110,10 +133,13 @@ public static class ModuleConstants
                     yield return TokenFilter;
                     yield return MinGram;
                     yield return MaxGram;
+                    yield return MinScore;
                     yield return SemanticSearchType;
                     yield return SemanticModelId;
                     yield return SemanticPipelineName;
                     yield return SemanticVectorModelDimensions;
+                    yield return SemanticBoost;
+                    yield return KeywordBoost;
                 }
             }
         }

--- a/src/VirtoCommerce.ElasticSearch8.Data/Extensions/SettingsExtensions.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Extensions/SettingsExtensions.cs
@@ -52,5 +52,23 @@ namespace VirtoCommerce.ElasticSearch8.Data.Extensions
         {
             return settingsManager.GetValue<int>(ModuleSettings.SemanticVectorModelDimensions);
         }
+
+        public static double? GetMinScore(this ISettingsManager settingsManager)
+        {
+            var value = (double)settingsManager.GetValue<decimal>(ModuleSettings.MinScore);
+            return value > 0 ? value : null;
+        }
+
+        public static float? GetKeywordBoost(this ISettingsManager settingsManager)
+        {
+            var value = (float)settingsManager.GetValue<decimal>(ModuleSettings.KeywordBoost);
+            return value > 0 ? value : null;
+        }
+
+        public static float? GetSemanticBoost(this ISettingsManager settingsManager)
+        {
+            var value = (float)settingsManager.GetValue<decimal>(ModuleSettings.SemanticBoost);
+            return value > 0 ? value : null;
+        }
     }
 }

--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearchRequestBuilder.cs
@@ -49,6 +49,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                 TrackScores = request?.Sorting?.Any(x => x.FieldName.EqualsInvariant(ModuleConstants.ScoreFieldName)),
                 Source = GetSourceFilters(request?.IncludeFields),
                 TrackTotalHits = new TrackHits(true),
+                MinScore = _settingsManager.GetMinScore(),
             };
 
             // use knn search and rank feature
@@ -90,6 +91,11 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             if (_settingsManager.GetSemanticSearchType() == ModuleConstants.ElserModel)
             {
                 var textExpansionQuery = GetTextExpansionKeywordSearchQuery(request);
+
+                // configure boost
+                textExpansionQuery.Boost = _settingsManager.GetSemanticBoost();
+                multiMatchQuery.Boost = _settingsManager.GetKeywordBoost();
+
                 var queries = new Query[] { textExpansionQuery, multiMatchQuery };
 
                 var boolQuery = new BoolQuery { Should = queries };

--- a/src/VirtoCommerce.ElasticSearch8.Web/Localizations/en.VirtoCommerce.ElasticSearch8.json
+++ b/src/VirtoCommerce.ElasticSearch8.Web/Localizations/en.VirtoCommerce.ElasticSearch8.json
@@ -19,6 +19,10 @@
           "description": "Maximum number of characters in a gram (requires rebuilding an index)"
         }
       },
+      "MinScore": {
+        "title": "Min Score",
+        "description": "Specifies the minimum score a document must have to be considered a match. Documents with scores below this threshold will not be included in the results. Set 0 to return all documents."
+      },
       "DeleteDuplicateIndexes": {
         "title": "Delete duplicate active indexes",
         "description": "Search and delete duplicate active indexes before Delete and build operation"
@@ -46,6 +50,14 @@
       "SemanticVectorModelDimensions": {
         "title": "Vector model dimensions number",
         "description": "Number of dimensions of the third party vector model. Typicaly found in the model description."
+      },
+      "KeywordBoost": {
+        "title": "Boost for keyword search",
+        "description": "Floating point number used as the constant relevance score for every document matching the Boost for keyword search. Defaults to 1.0."
+      },
+      "SemanticBoost": {
+        "title": "Boost for semantic search",
+        "description": "Floating point number used as the constant relevance score for every document matching the Boost for semantic search. Defaults to 1.0."
       }
     }
   }


### PR DESCRIPTION
## Description
feat: Allows to configure min_score. Documents with scores below this threshold will not be included in the results. Default value: 0.1. Set 0 to return all documents.
feat: Allows to configure boost for Keyword and Semantic Search (if semantic search is enabled). Default value is: 1.0.

![image](https://github.com/VirtoCommerce/vc-module-elastic-search-8/assets/7639413/5b082ce5-9e82-418b-9926-92475edeae85)

![image](https://github.com/VirtoCommerce/vc-module-elastic-search-8/assets/7639413/2b39962e-0333-44f3-b44d-fe1fd63e1dc9)


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-336
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.802.0-pr-11-135a.zip
