### PR TITLE
VCST-484: Apply MinScore for Keyword-Based Searches Only

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Web/Localizations/en.VirtoCommerce.ElasticSearch8.json
+++ b/src/VirtoCommerce.ElasticSearch8.Web/Localizations/en.VirtoCommerce.ElasticSearch8.json
@@ -21,7 +21,7 @@
       },
       "MinScore": {
         "title": "Min Score",
-        "description": "Specifies the minimum score a document must have to be considered a match. Documents with scores below this threshold will not be included in the results. Set 0 to return all documents."
+        "description": "Specifies the minimum score a document must have to be considered a match. Documents with scores below this threshold will not be included in the results. Set 0 to return all documents. Applied if Keyword is specified."
       },
       "DeleteDuplicateIndexes": {
         "title": "Delete duplicate active indexes",


### PR DESCRIPTION
## Description
fix: MinScore should be applied exclusively for keyword-based searches to prevent potential corruption of other requests.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-484
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.804.0-pr-13-2dad.zip
