### PR TITLE
VCST-4032: Increase default value of MaxGram from 20 to 50

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Core/ModuleConstants.cs
@@ -67,7 +67,7 @@ public static class ModuleConstants
                 Name = "VirtoCommerce.Search.ElasticSearch8.NGramTokenFilter.MaxGram",
                 GroupName = "Search|ElasticSearch8|General",
                 ValueType = SettingValueType.Integer,
-                DefaultValue = 20,
+                DefaultValue = 50,
             };
 
             public static SettingDescriptor MinScore { get; } = new()


### PR DESCRIPTION
## Description
feat:  Increase default value of MaxGram from 20 to 50

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4032
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.821.0-pr-33-a42d.zip