### PR TITLE
VCST-4779: 404 error silently swallowed

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
@@ -116,7 +116,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                 var providerRequest = _searchRequestBuilder.BuildRequest(request, indexName, documentType, availableFields);
                 var providerResponse = await Client.SearchAsync<SearchDocument>(providerRequest);
 
-                if (!providerResponse.IsValidResponse && providerResponse.ApiCallDetails.HttpStatusCode != (int)HttpStatusCode.NotFound)
+                if (!providerResponse.IsValidResponse)
                 {
                     ThrowException($"Search failed. {providerResponse.DebugInformation}", providerResponse.ApiCallDetails.OriginalException);
                 }
@@ -345,7 +345,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                 }
 
                 var providerResponse = await Client.SearchAsync<SearchDocument>(providerRequest);
-                if (!providerResponse.IsValidResponse && providerResponse.ApiCallDetails.HttpStatusCode != (int)HttpStatusCode.NotFound)
+                if (!providerResponse.IsValidResponse)
                 {
                     ThrowException($"Get suggestions failed. {providerResponse.DebugInformation}", providerResponse.ApiCallDetails.OriginalException);
                 }


### PR DESCRIPTION
## Description
fix: invalid Elasticsearch response now triggers ThrowException, ensuring missing index/alias errors are not silently ignored.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4779
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.1002.0-pr-41-8b0d.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, but changes error handling so previously-suppressed `404 NotFound` responses will now throw `SearchException`, which may affect callers expecting empty results.
> 
> **Overview**
> **Search and suggestion requests now throw on `404 NotFound` responses.**
> 
> In `ElasticSearch8Provider.SearchAsync` and `GetSuggestionsAsync`, the provider no longer special-cases HTTP 404 as non-fatal; any invalid Elasticsearch response now triggers `ThrowException`, ensuring missing index/alias errors are not silently ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b0da5c9e4e9bc6f9ecd088652ffe71f3c83ceb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->