### PR TITLE
VCST-4779: Suppress only index_not_found_exception

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
@@ -12,6 +12,7 @@ using Elastic.Clients.Elasticsearch.Fluent;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.ElasticSearch8.Core;
@@ -118,6 +119,13 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
 
                 if (!providerResponse.IsValidResponse)
                 {
+                    if (IsIndexNotFoundError(providerResponse))
+                    {
+                        // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case return empty search result.
+                        _logger.LogWarning($"Index {indexName} not found while trying to search. Returning empty result. Possible cause - index was not created yet or was deleted.");
+                        return AbstractTypeFactory<SearchResponse>.TryCreateInstance();
+                    }
+
                     ThrowException($"Search failed. {providerResponse.DebugInformation}", providerResponse.ApiCallDetails.OriginalException);
                 }
 
@@ -332,7 +340,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             {
                 if (request.Fields.IsNullOrEmpty())
                 {
-                    return new SuggestionResponse();
+                    return AbstractTypeFactory<SuggestionResponse>.TryCreateInstance();
                 }
 
                 var indexName = GetIndexName(request.UseBackupIndex, documentType);
@@ -341,13 +349,22 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                 var providerRequest = _searchRequestBuilder.BuildSuggestionRequest(request, indexName, documentType, availableFields);
                 if (providerRequest.Suggest is null)
                 {
-                    return new SuggestionResponse();
+                    return AbstractTypeFactory<SuggestionResponse>.TryCreateInstance();
                 }
 
                 var providerResponse = await Client.SearchAsync<SearchDocument>(providerRequest);
                 if (!providerResponse.IsValidResponse)
                 {
-                    ThrowException($"Get suggestions failed. {providerResponse.DebugInformation}", providerResponse.ApiCallDetails.OriginalException);
+                    if (IsIndexNotFoundError(providerResponse))
+                    {
+                        // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case return empty suggestions result.
+                        _logger.LogWarning($"Index {indexName} not found while trying to get suggestions.");
+                        return AbstractTypeFactory<SuggestionResponse>.TryCreateInstance();
+                    }
+                    else
+                    {
+                        ThrowException($"Get suggestions failed. {providerResponse.DebugInformation}", providerResponse.ApiCallDetails.OriginalException);
+                    }
                 }
 
                 var result = _searchResponseBuilder.ToSuggestionResponse(providerResponse, request);
@@ -363,6 +380,13 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                 ThrowException("Get suggestions failed.", ex);
                 return null;
             }
+        }
+
+        protected virtual bool IsIndexNotFoundError(ElasticsearchResponse response)
+        {
+            return !response.IsValidResponse &&
+                response.ApiCallDetails?.HttpStatusCode == (int)HttpStatusCode.NotFound &&
+                response?.ElasticsearchServerError?.Error?.Type == "index_not_found_exception";
         }
 
         protected virtual bool IsDenseVectorMode(IList<IndexDocument> documents)
@@ -537,8 +561,15 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             if (indexName != null)
             {
                 var response = await Client.Indices.DeleteAsync(indexName);
-                if (!response.IsValidResponse && response.ApiCallDetails.HttpStatusCode != (int)HttpStatusCode.NotFound)
+                if (!response.IsValidResponse)
                 {
+                    // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case just log information and return.
+                    if (IsIndexNotFoundError(response))
+                    {
+                        _logger.LogInformation($"Index {indexName} not found while trying to delete it. It may be already deleted.");
+                        return;
+                    }
+
                     ThrowException($"Failed to delete index. {response.DebugInformation}", response.ApiCallDetails.OriginalException);
                 }
             }

--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
@@ -386,7 +386,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
         {
             return !response.IsValidResponse &&
                 response.ApiCallDetails?.HttpStatusCode == (int)HttpStatusCode.NotFound &&
-                response?.ElasticsearchServerError?.Error?.Type == "index_not_found_exception";
+                response.ElasticsearchServerError?.Error?.Type == "index_not_found_exception";
         }
 
         protected virtual bool IsDenseVectorMode(IList<IndexDocument> documents)
@@ -566,7 +566,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                     // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case just log information and return.
                     if (IsIndexNotFoundError(response))
                     {
-                        _logger.LogInformation($"Index {indexName} not found while trying to delete it. It may be already deleted.");
+                        _logger.LogInformation("Index {indexName} not found while trying to delete it. It may be already deleted.", indexName);
                         return;
                     }
 

--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
@@ -122,7 +122,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                     if (IsIndexNotFoundError(providerResponse))
                     {
                         // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case return empty search result.
-                        _logger.LogWarning($"Index {indexName} not found while trying to search. Returning empty result. Possible cause - index was not created yet or was deleted.");
+                        _logger.LogWarning("Index {indexName} not found while trying to search. Returning empty result. Possible cause - index was not created yet or was deleted.", indexName);
                         return AbstractTypeFactory<SearchResponse>.TryCreateInstance();
                     }
 
@@ -358,7 +358,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
                     if (IsIndexNotFoundError(providerResponse))
                     {
                         // Suppress index not found error, because it can be normal in case when index was not created yet or was deleted. In this case return empty suggestions result.
-                        _logger.LogWarning($"Index {indexName} not found while trying to get suggestions.");
+                        _logger.LogWarning("Index {indexName} not found while trying to get suggestions.", indexName);
                         return AbstractTypeFactory<SuggestionResponse>.TryCreateInstance();
                     }
                     else


### PR DESCRIPTION
## Description
fix: Suppress index not found error, because it can be normal in case when index was not created yet. Before module suppressed all 404 elastic errors.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4779
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.1003.0-pr-42-e030.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Elasticsearch error-handling to suppress only true missing-index cases; other 404s will now throw, which may surface new failures in environments relying on prior broad suppression.
> 
> **Overview**
> Tightens 404 handling in `ElasticSearch8Provider` by introducing `IsIndexNotFoundError` and using it to **only** suppress `index_not_found_exception` during `SearchAsync`, `GetSuggestionsAsync`, and index deletion.
> 
> When the index is missing, these operations now log and return empty `SearchResponse`/`SuggestionResponse` (via `AbstractTypeFactory`) instead of throwing; all other invalid responses (including non-index 404s) still raise `SearchException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0308eb144ab4bee9881bb0261df0ad76b4ad87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->