### PR TITLE
VCST-5163: Stable 15 — ElasticSearch8 (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Core/VirtoCommerce.ElasticSearch8.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.19.14" />
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
+++ b/src/VirtoCommerce.ElasticSearch8.Data/Services/ElasticSearch8Provider.cs
@@ -606,51 +606,6 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             }
         }
 
-        [Obsolete("Use UpdateMappingAsync with documentType parameter", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        protected async Task UpdateMappingAsync(string indexName, Properties properties)
-        {
-            Properties newProperties;
-            Properties allProperties;
-
-            var mapping = await LoadMappingAsync(indexName);
-            var existingProperties = new Properties(mapping);
-
-            if (mapping.IsNullOrEmpty())
-            {
-                newProperties = properties;
-                allProperties = properties;
-            }
-            else
-            {
-
-                newProperties = new Properties();
-                allProperties = existingProperties;
-
-                foreach (var (name, value) in properties)
-                {
-                    if (!existingProperties.TryGetProperty(name, out _))
-                    {
-                        newProperties.Add(name, value);
-                        allProperties.Add(name, value);
-                    }
-                }
-            }
-
-            if (newProperties.Any())
-            {
-                var request = new PutMappingRequest(indexName) { Properties = newProperties };
-                var response = await Client.Indices.PutMappingAsync(request);
-
-                if (!response.IsValidResponse)
-                {
-                    ThrowException("Failed to submit mapping. " + response.DebugInformation, response.ApiCallDetails.OriginalException);
-                }
-            }
-
-            AddMappingToCache(indexName, allProperties);
-            await Client.Indices.RefreshAsync(indexName);
-        }
-
         protected virtual async Task UpdateMappingAsync(string documentType, string indexName, Properties properties)
         {
             var mapping = await LoadMappingAsync(indexName);
@@ -691,27 +646,7 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             return (newProperties, allProperties);
         }
 
-        [Obsolete("Use IElasticSearchDocumentConverter.ToProviderDocument", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        protected virtual SearchDocument ConvertToProviderDocument(IndexDocument document, IDictionary<PropertyName, IProperty> properties)
-        {
-            return _documentConverter.ToProviderDocument(null, document, properties);
-        }
-
         #region CreateIndex (move to index create service)
-
-        [Obsolete("Use CreateIndexAsync with documentType parameter", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        protected virtual async Task CreateIndexAsync(string indexName, string alias)
-        {
-            var response = await Client.Indices.CreateAsync(indexName, i => i
-                .Settings(x => ConfigureIndexSettings(x))
-                .Aliases(x => x.Add(alias, new AliasDescriptor())
-                ));
-
-            if (!response.ApiCallDetails.HasSuccessfulStatusCode)
-            {
-                ThrowException($"Failed to create index. {response.DebugInformation}", response.ApiCallDetails.OriginalException);
-            }
-        }
 
         protected virtual async Task CreateIndexAsync(string documentType, string indexName, string alias)
         {
@@ -724,22 +659,6 @@ namespace VirtoCommerce.ElasticSearch8.Data.Services
             {
                 ThrowException($"Failed to create index. {response.DebugInformation}", response.ApiCallDetails.OriginalException);
             }
-        }
-
-        [Obsolete("Use ConfigureIndexSettings with documentType parameter", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        protected virtual IndexSettingsDescriptor ConfigureIndexSettings(IndexSettingsDescriptor settings)
-        {
-            var fieldsLimit = _settingsManager.GetFieldsLimit();
-            var ngramDiff = _settingsManager.GetMaxGram() - _settingsManager.GetMinGram();
-
-            return settings
-                .MaxNgramDiff(ngramDiff)
-                .Mapping(mappingDescriptor => ConfigureMappingLimit(mappingDescriptor, fieldsLimit))
-                .Analysis(analysisDescriptor => analysisDescriptor
-                    .TokenFilters(ConfigureTokenFilters)
-                    .Analyzers(ConfigureAnalyzers)
-                    .Normalizers(ConfigureNormalizers)
-                );
         }
 
         protected virtual IndexSettingsDescriptor ConfigureIndexSettings(IndexSettingsDescriptor settings, string documentType)

--- a/src/VirtoCommerce.ElasticSearch8.Data/VirtoCommerce.ElasticSearch8.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearch8.Data/VirtoCommerce.ElasticSearch8.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ElasticSearch8.Core\VirtoCommerce.ElasticSearch8.Core.csproj" />

--- a/src/VirtoCommerce.ElasticSearch8.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticSearch8.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1006.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
   </dependencies>
 
   <title>Elastic Search 8</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 2). Platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave-1 deps (nuget.org). Branch actualized with latest dev. `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrades can surface breaking API changes from platform/search packages, and removing obsolete provider methods is safe only if nothing external still called them.
> 
> **Overview**
> Aligns the ElasticSearch8 module with **Stable 15** by raising VirtoCommerce platform packages to **3.1039.0**, Search module core to **3.1004.0**, and updating `module.manifest` `platformVersion` and `VirtoCommerce.Search` dependency to match.
> 
> **`ElasticSearch8Provider`** drops the obsolete overloads (VC0011) for index mapping, index creation, settings configuration, and document conversion—call sites already use the `documentType`-aware paths and `IElasticSearchDocumentConverter.ToProviderDocument`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9470638317e63501c58e50561b668f8de3835e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch8_3.1007.0-pr-46-5e94.zip